### PR TITLE
babel runtime

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@stackbit/gatsby-plugin-menus": "0.0.4",
+    "@babel/runtime": "7.0.0-beta.46",
     "chokidar": "^3.4.0",
     "classnames": "^2.2.6",
     "fs-extra": "^7.0.1",


### PR DESCRIPTION
added "@babel/runtime": "7.0.0-beta.46", to the package.json